### PR TITLE
feat: add delta and relative timestamp display modes

### DIFF
--- a/src/core/filter_worker.rs
+++ b/src/core/filter_worker.rs
@@ -152,9 +152,8 @@ impl FilterWorker {
 
                     // Parallel filtering with rayon
                     request.store.get_matching_ids(|display_msg, raw| {
-                        let matches_include =
-                            request.regex.is_match(display_msg).unwrap_or(false)
-                                || request.regex.is_match(raw).unwrap_or(false);
+                        let matches_include = request.regex.is_match(display_msg).unwrap_or(false)
+                            || request.regex.is_match(raw).unwrap_or(false);
 
                         if !matches_include {
                             return false;

--- a/src/core/log_store.rs
+++ b/src/core/log_store.rs
@@ -19,8 +19,8 @@
 use crate::core::session::{CrabFile, CRAB_FILE_VERSION};
 use crate::core::{SavedFilter, SavedHighlight};
 use crate::filetype::{
-    btsnoop::BtsnoopFileType, bugreport::BugreportFileType, dlt::DltFileType,
-    dmesg::DmesgFileType, generic::GenericFileType, logcat::LogcatFileType, pcap::PcapFileType,
+    btsnoop::BtsnoopFileType, bugreport::BugreportFileType, dlt::DltFileType, dmesg::DmesgFileType,
+    generic::GenericFileType, logcat::LogcatFileType, pcap::PcapFileType,
 };
 use crate::filetype::{
     btsnoop::BtsnoopLogLine, dlt::DltLogLine, dmesg::DmesgLogLine, generic::GenericLogLine,

--- a/src/filetype/dmesg.rs
+++ b/src/filetype/dmesg.rs
@@ -264,7 +264,10 @@ pub fn parse_dmesg_line(raw: String, line_number: usize) -> Option<DmesgLogLine>
     let message = caps[3].to_string();
     let total_micros = secs * 1_000_000 + micros;
     let timestamp = Utc
-        .timestamp_opt(total_micros / 1_000_000, ((total_micros % 1_000_000) * 1_000) as u32)
+        .timestamp_opt(
+            total_micros / 1_000_000,
+            ((total_micros % 1_000_000) * 1_000) as u32,
+        )
         .single()?
         .with_timezone(&Local);
     Some(DmesgLogLine::new(raw, timestamp, message, line_number))
@@ -286,10 +289,7 @@ mod tests {
     fn test_parse_large_timestamp() {
         let raw = "[42798.603585] init: service 'foo' requested start".to_string();
         let line = parse_dmesg_line(raw, 2).expect("should parse dmesg line");
-        assert_eq!(
-            line.message_text,
-            "init: service 'foo' requested start"
-        );
+        assert_eq!(line.message_text, "init: service 'foo' requested start");
         // 42798 seconds + 603585 microseconds
         assert_eq!(
             line.timestamp.timestamp_micros(),
@@ -335,8 +335,14 @@ mod tests {
         let mut ft = make_reader(content);
         let lines = ft.read(100).expect("read");
         assert_eq!(lines.len(), 2);
-        assert_eq!(lines[0].message_text, "First line\ncontinuation one\ncontinuation two");
-        assert_eq!(lines[0].raw_line, "[   1.000000] First line\ncontinuation one\ncontinuation two");
+        assert_eq!(
+            lines[0].message_text,
+            "First line\ncontinuation one\ncontinuation two"
+        );
+        assert_eq!(
+            lines[0].raw_line,
+            "[   1.000000] First line\ncontinuation one\ncontinuation two"
+        );
         assert_eq!(lines[1].message_text, "Second entry");
     }
 

--- a/src/filetype/pcap.rs
+++ b/src/filetype/pcap.rs
@@ -197,7 +197,10 @@ impl LineType for PcapLogLine {
                         } else {
                             format!(" {}", sd_info.entries.join(", "))
                         };
-                        return format!("{} [SOME/IP-SD {}{}]", base_msg, sd_info.message_type, entries_str);
+                        return format!(
+                            "{} [SOME/IP-SD {}{}]",
+                            base_msg, sd_info.message_type, entries_str
+                        );
                     }
                 }
             }
@@ -248,9 +251,9 @@ impl LineType for PcapLogLine {
             ui.separator();
             let is_active = file_state.is_someip_sd_active(&key);
             let label = if is_active {
-                format!("🔓 Disable SOME/IP SD decoding for {}", key)
+                format!("🔓 Disable SOME/IP SD decoding for {key}")
             } else {
-                format!("🔒 Enable SOME/IP SD decoding for {}", key)
+                format!("🔒 Enable SOME/IP SD decoding for {key}")
             };
             if ui.button(label).clicked() {
                 file_state.toggle_someip_sd(key);
@@ -695,30 +698,10 @@ pub struct SomeIpSdInfo {
     pub entries: Vec<String>,
 }
 
-/// Decode SOME/IP SD (Service Discovery) payload using someip_parse library
+/// Decode SOME/IP SD (Service Discovery) payload using `someip_parse` library
 fn decode_someip_sd(payload: &[u8]) -> Option<SomeIpSdInfo> {
     use someip_parse::{SdEntry, SdOption, SomeipMsgSlice};
     use std::net::{Ipv4Addr, Ipv6Addr};
-
-    // Parse SOME/IP message
-    let msg = match SomeipMsgSlice::from_slice(payload) {
-        Ok(msg) => msg,
-        Err(_) => return None,
-    };
-
-    // Check if this is a SOME/IP-SD message
-    if !msg.is_someip_sd() {
-        return None;
-    }
-
-    let someip_payload = msg.payload();
-
-    // Parse SD header using the library
-    let mut cursor = std::io::Cursor::new(someip_payload);
-    let sd_header = match someip_parse::SdHeader::read(&mut cursor) {
-        Ok(header) => header,
-        Err(_) => return None,
-    };
 
     /// Format a slice of `SdOption` entries as compact endpoint strings.
     fn format_endpoints(opts: &[SdOption]) -> Vec<String> {
@@ -748,12 +731,16 @@ fn decode_someip_sd(payload: &[u8]) -> Option<SomeIpSdInfo> {
                     proto_str(e.transport_protocol),
                     e.port,
                 )),
-                _ => None,
+                SdOption::Configuration(_)
+                | SdOption::LoadBalancing(_)
+                | SdOption::Ipv4SdEndpoint(_)
+                | SdOption::Ipv6SdEndpoint(_)
+                | SdOption::UnknownDiscardable(_) => None,
             })
             .collect()
     }
 
-    fn proto_str(p: someip_parse::TransportProtocol) -> &'static str {
+    const fn proto_str(p: someip_parse::TransportProtocol) -> &'static str {
         match p {
             someip_parse::TransportProtocol::Tcp => "TCP",
             someip_parse::TransportProtocol::Udp => "UDP",
@@ -762,13 +749,7 @@ fn decode_someip_sd(payload: &[u8]) -> Option<SomeIpSdInfo> {
     }
 
     /// Collect endpoint options for an entry's two option runs.
-    fn entry_endpoints(
-        opts: &[SdOption],
-        idx1: u8,
-        num1: u8,
-        idx2: u8,
-        num2: u8,
-    ) -> String {
+    fn entry_endpoints(opts: &[SdOption], idx1: u8, num1: u8, idx2: u8, num2: u8) -> String {
         let run1_start = idx1 as usize;
         let run1_end = (run1_start + num1 as usize).min(opts.len());
         let run2_start = idx2 as usize;
@@ -783,6 +764,24 @@ fn decode_someip_sd(payload: &[u8]) -> Option<SomeIpSdInfo> {
             format!(" @ {}", endpoints.join(", "))
         }
     }
+
+    // Parse SOME/IP message
+    let Ok(msg) = SomeipMsgSlice::from_slice(payload) else {
+        return None;
+    };
+
+    // Check if this is a SOME/IP-SD message
+    if !msg.is_someip_sd() {
+        return None;
+    }
+
+    let someip_payload = msg.payload();
+
+    // Parse SD header using the library
+    let mut cursor = std::io::Cursor::new(someip_payload);
+    let Ok(sd_header) = someip_parse::SdHeader::read(&mut cursor) else {
+        return None;
+    };
 
     // Format entries for display
     let entries = sd_header
@@ -826,12 +825,7 @@ fn decode_someip_sd(payload: &[u8]) -> Option<SomeIpSdInfo> {
                 );
                 format!(
                     "{}(0x{:04x}:0x{:04x} eg=0x{:04x} TTL={}{})",
-                    entry_type,
-                    e.service_id,
-                    e.instance_id,
-                    e.eventgroup_id,
-                    e.ttl,
-                    endpoints,
+                    entry_type, e.service_id, e.instance_id, e.eventgroup_id, e.ttl, endpoints,
                 )
             }
         })
@@ -950,7 +944,14 @@ fn parse_ipv4_packet(
             None,
             None,
         ),
-        _ => (format!("IP/{protocol}"), None, None, String::new(), None, None),
+        _ => (
+            format!("IP/{protocol}"),
+            None,
+            None,
+            String::new(),
+            None,
+            None,
+        ),
     };
     let is_abnormal = tcp_details
         .as_ref()

--- a/src/ui/tabs/filter_tab/filter_bar.rs
+++ b/src/ui/tabs/filter_tab/filter_bar.rs
@@ -21,10 +21,12 @@ use std::sync::Arc;
 use egui::{Color32, Ui};
 
 use crate::{
-    config::GlobalConfig, core::LogStore, ui::{
+    config::GlobalConfig,
+    core::LogStore,
+    ui::{
         session_state::SessionState,
         tabs::filter_tab::{filter_state::FilterState, log_table::TimestampMode},
-    }
+    },
 };
 
 /// Events emitted by the filter bar that need to bubble up to the parent.
@@ -106,7 +108,7 @@ impl FilterBar {
             Self::render_case_checkbox(ui, filter, log_view_state);
             Self::render_validation_status(ui, filter);
             Self::render_convert_to_highlight_button(ui, &mut events);
-            Self::render_timestamp_mode_dropdown(ui, filter, log_view_state.store.clone());
+            Self::render_timestamp_mode_dropdown(ui, filter, &log_view_state.store);
 
             // Export button for filtered results
             if ui
@@ -448,7 +450,11 @@ impl FilterBar {
         }
     }
 
-    fn render_timestamp_mode_dropdown(ui: &mut Ui, filter: &mut FilterState, store: Arc<LogStore>) {
+    fn render_timestamp_mode_dropdown(
+        ui: &mut Ui,
+        filter: &mut FilterState,
+        store: &Arc<LogStore>,
+    ) {
         let filtered_indices = filter.search.get_filtered_indices_cached();
         let first_timestamp = filtered_indices
             .first()

--- a/src/ui/tabs/filter_tab/filter_bar.rs
+++ b/src/ui/tabs/filter_tab/filter_bar.rs
@@ -20,7 +20,10 @@ use egui::{Color32, Ui};
 
 use crate::{
     config::GlobalConfig,
-    ui::{session_state::SessionState, tabs::filter_tab::filter_state::FilterState},
+    ui::{
+        session_state::SessionState,
+        tabs::filter_tab::{filter_state::FilterState, log_table::TimestampMode},
+    },
 };
 
 /// Events emitted by the filter bar that need to bubble up to the parent.
@@ -102,6 +105,7 @@ impl FilterBar {
             Self::render_case_checkbox(ui, filter, log_view_state);
             Self::render_validation_status(ui, filter);
             Self::render_convert_to_highlight_button(ui, &mut events);
+            Self::render_timestamp_mode_dropdown(ui, filter);
 
             // Export button for filtered results
             if ui
@@ -440,6 +444,46 @@ impl FilterBar {
             .clicked()
         {
             events.push(FilterInternalEvent::ConvertToHighlight);
+        }
+    }
+
+    fn render_timestamp_mode_dropdown(ui: &mut Ui, filter: &mut FilterState) {
+        let selected_text = match filter.timestamp_mode {
+            TimestampMode::Absolute => "🕐 Absolute",
+            TimestampMode::Delta => "Δ Delta",
+            TimestampMode::Relative if filter.time_zero_store_id.is_some() => "⏱ Relative (marker)",
+            TimestampMode::Relative => "⏱ Relative",
+        };
+
+        egui::ComboBox::from_id_salt("timestamp_mode_combo")
+            .selected_text(selected_text)
+            .width(140.0)
+            .show_ui(ui, |ui| {
+                ui.selectable_value(
+                    &mut filter.timestamp_mode,
+                    TimestampMode::Absolute,
+                    "🕐 Absolute time",
+                );
+                ui.selectable_value(
+                    &mut filter.timestamp_mode,
+                    TimestampMode::Delta,
+                    "Δ Delta time",
+                );
+                ui.selectable_value(
+                    &mut filter.timestamp_mode,
+                    TimestampMode::Relative,
+                    "⏱ Relative time",
+                );
+            });
+
+        if filter.time_zero_store_id.is_some() {
+            if ui
+                .small_button("✖")
+                .on_hover_text("Clear time zero marker")
+                .clicked()
+            {
+                filter.time_zero_store_id = None;
+            }
         }
     }
 }

--- a/src/ui/tabs/filter_tab/filter_bar.rs
+++ b/src/ui/tabs/filter_tab/filter_bar.rs
@@ -16,14 +16,15 @@
 // You should have received a copy of the GNU General Public License
 // along with LogCrab.  If not, see <https://www.gnu.org/licenses/>.
 
+use std::sync::Arc;
+
 use egui::{Color32, Ui};
 
 use crate::{
-    config::GlobalConfig,
-    ui::{
+    config::GlobalConfig, core::LogStore, ui::{
         session_state::SessionState,
         tabs::filter_tab::{filter_state::FilterState, log_table::TimestampMode},
-    },
+    }
 };
 
 /// Events emitted by the filter bar that need to bubble up to the parent.
@@ -105,7 +106,7 @@ impl FilterBar {
             Self::render_case_checkbox(ui, filter, log_view_state);
             Self::render_validation_status(ui, filter);
             Self::render_convert_to_highlight_button(ui, &mut events);
-            Self::render_timestamp_mode_dropdown(ui, filter);
+            Self::render_timestamp_mode_dropdown(ui, filter, log_view_state.store.clone());
 
             // Export button for filtered results
             if ui
@@ -447,12 +448,15 @@ impl FilterBar {
         }
     }
 
-    fn render_timestamp_mode_dropdown(ui: &mut Ui, filter: &mut FilterState) {
+    fn render_timestamp_mode_dropdown(ui: &mut Ui, filter: &mut FilterState, store: Arc<LogStore>) {
+        let filtered_indices = filter.search.get_filtered_indices_cached();
+        let first_timestamp = filtered_indices
+            .first()
+            .and_then(|idx| store.adjusted_timestamp(idx));
         let selected_text = match filter.timestamp_mode {
             TimestampMode::Absolute => "🕐 Absolute",
             TimestampMode::Delta => "Δ Delta",
-            TimestampMode::Relative if filter.time_zero_store_id.is_some() => "⏱ Relative (marker)",
-            TimestampMode::Relative => "⏱ Relative",
+            TimestampMode::Relative(_) => "⏱ Relative",
         };
 
         egui::ComboBox::from_id_salt("timestamp_mode_combo")
@@ -469,21 +473,13 @@ impl FilterBar {
                     TimestampMode::Delta,
                     "Δ Delta time",
                 );
-                ui.selectable_value(
-                    &mut filter.timestamp_mode,
-                    TimestampMode::Relative,
-                    "⏱ Relative time",
-                );
+                if let Some(first_ts) = first_timestamp {
+                    ui.selectable_value(
+                        &mut filter.timestamp_mode,
+                        TimestampMode::Relative(first_ts),
+                        "⏱ Relative time",
+                    );
+                }
             });
-
-        if filter.time_zero_store_id.is_some() {
-            if ui
-                .small_button("✖")
-                .on_hover_text("Clear time zero marker")
-                .clicked()
-            {
-                filter.time_zero_store_id = None;
-            }
-        }
     }
 }

--- a/src/ui/tabs/filter_tab/filter_state.rs
+++ b/src/ui/tabs/filter_tab/filter_state.rs
@@ -44,10 +44,6 @@ pub struct FilterState {
 
     /// How the timestamp column displays time (absolute or delta).
     pub timestamp_mode: TimestampMode,
-
-    /// Optional reference row for delta-time mode.
-    /// When set, all delta values are relative to this row's timestamp.
-    pub time_zero_store_id: Option<StoreID>,
 }
 
 impl FilterState {
@@ -61,7 +57,6 @@ impl FilterState {
             histogram_cache: HistogramCache::new(filter_id),
             column_widths: ColumnWidths::default(),
             timestamp_mode: TimestampMode::default(),
-            time_zero_store_id: None,
         }
     }
 
@@ -104,7 +99,6 @@ impl From<&SavedFilter> for FilterState {
             histogram_cache: HistogramCache::new(filter_id),
             column_widths: ColumnWidths::default(),
             timestamp_mode: TimestampMode::default(),
-            time_zero_store_id: None,
         }
     }
 }

--- a/src/ui/tabs/filter_tab/filter_state.rs
+++ b/src/ui/tabs/filter_tab/filter_state.rs
@@ -19,7 +19,7 @@
 use crate::core::log_store::StoreID;
 use crate::core::{SavedFilter, SearchRule};
 use crate::ui::tabs::filter_tab::histogram::HistogramCache;
-use crate::ui::tabs::filter_tab::log_table::ColumnWidths;
+use crate::ui::tabs::filter_tab::log_table::{ColumnWidths, TimestampMode};
 use egui::Color32;
 
 /// Represents a single filter view with its own search criteria and cached results.
@@ -41,6 +41,13 @@ pub struct FilterState {
 
     /// Column widths for the log table
     pub column_widths: ColumnWidths,
+
+    /// How the timestamp column displays time (absolute or delta).
+    pub timestamp_mode: TimestampMode,
+
+    /// Optional reference row for delta-time mode.
+    /// When set, all delta values are relative to this row's timestamp.
+    pub time_zero_store_id: Option<StoreID>,
 }
 
 impl FilterState {
@@ -53,6 +60,8 @@ impl FilterState {
             closest_row_index: None,
             histogram_cache: HistogramCache::new(filter_id),
             column_widths: ColumnWidths::default(),
+            timestamp_mode: TimestampMode::default(),
+            time_zero_store_id: None,
         }
     }
 
@@ -94,6 +103,8 @@ impl From<&SavedFilter> for FilterState {
             closest_row_index: None,
             histogram_cache: HistogramCache::new(filter_id),
             column_widths: ColumnWidths::default(),
+            timestamp_mode: TimestampMode::default(),
+            time_zero_store_id: None,
         }
     }
 }

--- a/src/ui/tabs/filter_tab/log_table.rs
+++ b/src/ui/tabs/filter_tab/log_table.rs
@@ -65,8 +65,6 @@ pub enum LogTableEvent {
     SetTimeZero {
         line_index: StoreID,
     },
-    /// User cleared the time-zero reference from the header context menu.
-    ClearTimeZero,
 }
 
 /// Convert anomaly score to color with continuous gradient
@@ -327,7 +325,7 @@ impl LogTable {
                     &mut events,
                     dark_mode,
                     &mut filter.column_widths,
-                    &mut filter.timestamp_mode,
+                    filter.timestamp_mode,
                     filter.time_zero_store_id,
                 );
             });
@@ -391,12 +389,12 @@ impl LogTable {
         events: &mut Vec<LogTableEvent>,
         dark_mode: bool,
         column_widths: &mut ColumnWidths,
-        timestamp_mode: &mut TimestampMode,
+        timestamp_mode: TimestampMode,
         time_zero_store_id: Option<StoreID>,
     ) {
         // Resolve the time-zero reference timestamp for Relative mode.
         // Priority: explicit user-pinned row > oldest visible message.
-        let time_zero_timestamp = if *timestamp_mode == TimestampMode::Relative {
+        let time_zero_timestamp = if timestamp_mode == TimestampMode::Relative {
             if let Some(id) = time_zero_store_id {
                 store.adjusted_timestamp(&id)
             } else {
@@ -411,7 +409,7 @@ impl LogTable {
 
         table
             .header(20.0, |mut header| {
-                Self::render_header(&mut header, column_widths, timestamp_mode, time_zero_store_id, events);
+                Self::render_header(&mut header, column_widths, timestamp_mode, time_zero_store_id);
             })
             .body(|body| {
                 profiling::scope!("LogTable::body");
@@ -426,7 +424,7 @@ impl LogTable {
                     all_filter_highlights,
                     events,
                     dark_mode,
-                    *timestamp_mode,
+                    timestamp_mode,
                     time_zero_timestamp,
                 );
             });
@@ -435,9 +433,8 @@ impl LogTable {
     fn render_header(
         header: &mut egui_extras::TableRow,
         column_widths: &mut ColumnWidths,
-        timestamp_mode: &mut TimestampMode,
+        timestamp_mode: TimestampMode,
         time_zero_store_id: Option<StoreID>,
-        events: &mut Vec<LogTableEvent>,
     ) {
         header.col(|ui| {
             column_widths.source = ui.available_width();
@@ -449,7 +446,7 @@ impl LogTable {
         });
         header.col(|ui| {
             column_widths.timestamp = ui.available_width();
-            let label = match *timestamp_mode {
+            let label = match timestamp_mode {
                 TimestampMode::Absolute => {
                     let now = Local::now();
                     let offset = now.offset();
@@ -459,39 +456,7 @@ impl LogTable {
                 TimestampMode::Relative if time_zero_store_id.is_some() => "⏱ Relative (marker)".to_string(),
                 TimestampMode::Relative => "⏱ Relative".to_string(),
             };
-            let response = ui.strong(label);
-            response.context_menu(|ui| {
-                ui.label("Timestamp display:");
-                ui.separator();
-                if ui
-                    .selectable_label(*timestamp_mode == TimestampMode::Absolute, "🕐 Absolute time")
-                    .clicked()
-                {
-                    *timestamp_mode = TimestampMode::Absolute;
-                    ui.close();
-                }
-                if ui
-                    .selectable_label(*timestamp_mode == TimestampMode::Delta, "Δ Delta time")
-                    .clicked()
-                {
-                    *timestamp_mode = TimestampMode::Delta;
-                    ui.close();
-                }
-                if ui
-                    .selectable_label(*timestamp_mode == TimestampMode::Relative, "⏱ Relative time")
-                    .clicked()
-                {
-                    *timestamp_mode = TimestampMode::Relative;
-                    ui.close();
-                }
-                if time_zero_store_id.is_some() {
-                    ui.separator();
-                    if ui.button("✖ Clear time zero marker").clicked() {
-                        events.push(LogTableEvent::ClearTimeZero);
-                        ui.close();
-                    }
-                }
-            });
+            ui.strong(label);
         });
         header.col(|ui| {
             column_widths.message = ui.available_width();

--- a/src/ui/tabs/filter_tab/log_table.rs
+++ b/src/ui/tabs/filter_tab/log_table.rs
@@ -332,24 +332,6 @@ impl LogTable {
                 );
             });
 
-        // Apply events that affect FilterState directly (SetTimeZero, ClearTimeZero)
-        let mut i = 0;
-        while i < events.len() {
-            match &events[i] {
-                LogTableEvent::SetTimeZero { line_index } => {
-                    filter.time_zero_store_id = Some(*line_index);
-                    events.remove(i);
-                }
-                LogTableEvent::ClearTimeZero => {
-                    filter.time_zero_store_id = None;
-                    events.remove(i);
-                }
-                _ => {
-                    i += 1;
-                }
-            }
-        }
-
         events
     }
 

--- a/src/ui/tabs/filter_tab/log_table.rs
+++ b/src/ui/tabs/filter_tab/log_table.rs
@@ -25,15 +25,48 @@ use crate::{
     },
     ui::{filter_highlight::FilterHighlight, tabs::filter_tab::filter_state::FilterState},
 };
-use chrono::Local;
+use chrono::{DateTime, Local};
 use egui::{Color32, RichText, Ui};
 use egui_extras::{Column, TableBuilder};
+
+/// Controls how the timestamp column displays time values.
+#[derive(Default, Clone, Copy, PartialEq)]
+pub enum TimestampMode {
+    /// Show the absolute wall-clock time for each log line (default).
+    /// Example: `2026-02-11 13:45:49.663`
+    #[default]
+    Absolute,
+    /// Show the elapsed time since the previous visible log line.
+    /// First visible row shows `0.000s`. Example: `-0.532s`
+    Delta,
+    /// Show the elapsed time from a fixed time-zero reference.
+    /// Defaults to the oldest visible message when no marker is pinned.
+    /// Example: `120243.423s`
+    Relative,
+}
+
+/// Format a duration as seconds with 3 decimal places.
+/// Negative durations include a leading `-`; positive ones have no sign prefix.
+fn format_seconds(diff: chrono::Duration) -> String {
+    let secs = diff.num_milliseconds() as f64 / 1000.0;
+    format!("{secs:.3}s")
+}
 
 /// Events emitted by the log table
 #[derive(Clone)]
 pub enum LogTableEvent {
-    LineClicked { line_index: StoreID },
-    BookmarkToggled { line_index: StoreID },
+    LineClicked {
+        line_index: StoreID,
+    },
+    BookmarkToggled {
+        line_index: StoreID,
+    },
+    /// User requested this line to be the delta-time reference (time zero).
+    SetTimeZero {
+        line_index: StoreID,
+    },
+    /// User cleared the time-zero reference from the header context menu.
+    ClearTimeZero,
 }
 
 /// Convert anomaly score to color with continuous gradient
@@ -202,6 +235,14 @@ impl LogTable {
             // Type-specific context menu items (DLT calibration for typed sources).
             store.render_typed_context_menu_items(&line_idx, ui);
 
+            // Delta time zero marker
+            if ui.button("⏱ Set as time zero").clicked() {
+                events.push(LogTableEvent::SetTimeZero {
+                    line_index: line_idx,
+                });
+                ui.close();
+            }
+
             ui.separator();
 
             if ui.button("📋 Copy Message").clicked() {
@@ -286,8 +327,28 @@ impl LogTable {
                     &mut events,
                     dark_mode,
                     &mut filter.column_widths,
+                    &mut filter.timestamp_mode,
+                    filter.time_zero_store_id,
                 );
             });
+
+        // Apply events that affect FilterState directly (SetTimeZero, ClearTimeZero)
+        let mut i = 0;
+        while i < events.len() {
+            match &events[i] {
+                LogTableEvent::SetTimeZero { line_index } => {
+                    filter.time_zero_store_id = Some(*line_index);
+                    events.remove(i);
+                }
+                LogTableEvent::ClearTimeZero => {
+                    filter.time_zero_store_id = None;
+                    events.remove(i);
+                }
+                _ => {
+                    i += 1;
+                }
+            }
+        }
 
         events
     }
@@ -348,10 +409,27 @@ impl LogTable {
         events: &mut Vec<LogTableEvent>,
         dark_mode: bool,
         column_widths: &mut ColumnWidths,
+        timestamp_mode: &mut TimestampMode,
+        time_zero_store_id: Option<StoreID>,
     ) {
+        // Resolve the time-zero reference timestamp for Relative mode.
+        // Priority: explicit user-pinned row > oldest visible message.
+        let time_zero_timestamp = if *timestamp_mode == TimestampMode::Relative {
+            if let Some(id) = time_zero_store_id {
+                store.adjusted_timestamp(&id)
+            } else {
+                // Default: oldest visible message.
+                filtered_indices.first().and_then(|id| {
+                    store.adjusted_timestamp(id)
+                })
+            }
+        } else {
+            None
+        };
+
         table
             .header(20.0, |mut header| {
-                Self::render_header(&mut header, column_widths);
+                Self::render_header(&mut header, column_widths, timestamp_mode, time_zero_store_id, events);
             })
             .body(|body| {
                 profiling::scope!("LogTable::body");
@@ -366,11 +444,19 @@ impl LogTable {
                     all_filter_highlights,
                     events,
                     dark_mode,
+                    *timestamp_mode,
+                    time_zero_timestamp,
                 );
             });
     }
 
-    fn render_header(header: &mut egui_extras::TableRow, column_widths: &mut ColumnWidths) {
+    fn render_header(
+        header: &mut egui_extras::TableRow,
+        column_widths: &mut ColumnWidths,
+        timestamp_mode: &mut TimestampMode,
+        time_zero_store_id: Option<StoreID>,
+        events: &mut Vec<LogTableEvent>,
+    ) {
         header.col(|ui| {
             column_widths.source = ui.available_width();
             ui.strong("Source");
@@ -381,9 +467,49 @@ impl LogTable {
         });
         header.col(|ui| {
             column_widths.timestamp = ui.available_width();
-            let now = Local::now();
-            let offset = now.offset();
-            ui.strong(format!("Timestamp (UTC{offset})"));
+            let label = match *timestamp_mode {
+                TimestampMode::Absolute => {
+                    let now = Local::now();
+                    let offset = now.offset();
+                    format!("Timestamp (UTC{offset})")
+                }
+                TimestampMode::Delta => "Δ Time".to_string(),
+                TimestampMode::Relative if time_zero_store_id.is_some() => "⏱ Relative (marker)".to_string(),
+                TimestampMode::Relative => "⏱ Relative".to_string(),
+            };
+            let response = ui.strong(label);
+            response.context_menu(|ui| {
+                ui.label("Timestamp display:");
+                ui.separator();
+                if ui
+                    .selectable_label(*timestamp_mode == TimestampMode::Absolute, "🕐 Absolute time")
+                    .clicked()
+                {
+                    *timestamp_mode = TimestampMode::Absolute;
+                    ui.close();
+                }
+                if ui
+                    .selectable_label(*timestamp_mode == TimestampMode::Delta, "Δ Delta time")
+                    .clicked()
+                {
+                    *timestamp_mode = TimestampMode::Delta;
+                    ui.close();
+                }
+                if ui
+                    .selectable_label(*timestamp_mode == TimestampMode::Relative, "⏱ Relative time")
+                    .clicked()
+                {
+                    *timestamp_mode = TimestampMode::Relative;
+                    ui.close();
+                }
+                if time_zero_store_id.is_some() {
+                    ui.separator();
+                    if ui.button("✖ Clear time zero marker").clicked() {
+                        events.push(LogTableEvent::ClearTimeZero);
+                        ui.close();
+                    }
+                }
+            });
         });
         header.col(|ui| {
             column_widths.message = ui.available_width();
@@ -407,6 +533,8 @@ impl LogTable {
         all_filter_highlights: &[FilterHighlight],
         events: &mut Vec<LogTableEvent>,
         dark_mode: bool,
+        timestamp_mode: TimestampMode,
+        time_zero_timestamp: Option<DateTime<Local>>,
     ) {
         let visible_lines = filtered_indices.len();
 
@@ -416,6 +544,9 @@ impl LogTable {
             ctx.data(|d| d.get_temp(hover_storage_id)).flatten();
 
         let mut current_hovered_row: Option<usize> = None;
+
+        // Track the previous row's display time for Delta mode (consecutive-line differences).
+        let mut prev_row_timestamp: Option<DateTime<Local>> = None;
 
         body.rows(18.0, visible_lines, |mut row| {
             let row_index = row.index();
@@ -435,7 +566,14 @@ impl LogTable {
                 all_filter_highlights,
                 events,
                 dark_mode,
+                timestamp_mode,
+                prev_row_timestamp,
+                time_zero_timestamp,
             );
+
+            if let Some(ts) = store.adjusted_timestamp(&filtered_indices[row_index]) {
+                prev_row_timestamp = Some(ts);
+            }
 
             // Check if pointer is over this row for next frame
             if row.response().contains_pointer() {
@@ -462,6 +600,9 @@ impl LogTable {
         all_filter_highlights: &[FilterHighlight],
         events: &mut Vec<LogTableEvent>,
         dark_mode: bool,
+        timestamp_mode: TimestampMode,
+        prev_row_timestamp: Option<DateTime<Local>>,
+        time_zero_timestamp: Option<DateTime<Local>>,
     ) -> Option<LogTableEvent> {
         let row_index = row.index();
         let line_idx = filtered_indices[row_index];
@@ -499,6 +640,9 @@ impl LogTable {
             bookmarked_lines,
             all_filter_highlights,
             dark_mode,
+            timestamp_mode,
+            prev_row_timestamp,
+            time_zero_timestamp,
         );
 
         // Row-level interaction handling (union column and row responses)
@@ -536,6 +680,9 @@ impl LogTable {
         bookmarked_lines: &std::collections::HashMap<StoreID, String>,
         all_filter_highlights: &[FilterHighlight],
         dark_mode: bool,
+        timestamp_mode: TimestampMode,
+        prev_row_timestamp: Option<DateTime<Local>>,
+        time_zero_timestamp: Option<DateTime<Local>>,
     ) -> egui::Response {
         let responses = [
             Self::render_source_column(
@@ -568,6 +715,9 @@ impl LogTable {
                 is_bookmarked,
                 color,
                 dark_mode,
+                timestamp_mode,
+                prev_row_timestamp,
+                time_zero_timestamp,
             ),
             Self::render_message_column(
                 row,
@@ -688,6 +838,8 @@ impl LogTable {
     }
 
     #[allow(clippy::fn_params_excessive_bools)]
+    #[allow(clippy::too_many_arguments)]
+    /// Returns `(column response, display timestamp of this row)`.
     fn render_timestamp_column(
         row: &mut egui_extras::TableRow,
         store: &LogStore,
@@ -697,6 +849,9 @@ impl LogTable {
         is_bookmarked: bool,
         color: Color32,
         dark_mode: bool,
+        timestamp_mode: TimestampMode,
+        prev_row_timestamp: Option<DateTime<Local>>,
+        time_zero_timestamp: Option<DateTime<Local>>,
     ) -> egui::Response {
         let mut response: Option<egui::Response> = None;
         let (_, col_response) = row.col(|ui| {
@@ -716,7 +871,20 @@ impl LogTable {
                 return;
             };
 
-            let timestamp_str = display_time.format("%Y-%m-%d %H:%M:%S%.3f").to_string();
+            let timestamp_str = match timestamp_mode {
+                TimestampMode::Absolute => {
+                    display_time.format("%Y-%m-%d %H:%M:%S%.3f").to_string()
+                }
+                TimestampMode::Delta => match prev_row_timestamp {
+                    None => "0.000s".to_string(),
+                    Some(prev) => format_seconds(display_time.signed_duration_since(prev)),
+                },
+                TimestampMode::Relative => match time_zero_timestamp {
+                    None => "0.000s".to_string(),
+                    Some(t0) => format_seconds(display_time.signed_duration_since(t0)),
+                },
+            };
+
             let text = RichText::new(timestamp_str).color(color);
             response = Some(ui.add(egui::Label::new(text).sense(egui::Sense::click())));
         });

--- a/src/ui/tabs/filter_tab/log_table.rs
+++ b/src/ui/tabs/filter_tab/log_table.rs
@@ -20,10 +20,8 @@ use std::sync::Arc;
 
 use crate::{
     core::{
-        log_store::{LogLine, StoreID},
-        LogStore,
-    },
-    ui::{filter_highlight::FilterHighlight, tabs::filter_tab::filter_state::FilterState},
+        LogStore, log_store::{LogLine, StoreID}
+    }, parser::format_time_diff, ui::{filter_highlight::FilterHighlight, tabs::filter_tab::filter_state::FilterState}
 };
 use chrono::{DateTime, Local};
 use egui::{Color32, RichText, Ui};
@@ -43,13 +41,6 @@ pub enum TimestampMode {
     /// Defaults to the oldest visible message when no marker is pinned.
     /// Example: `120243.423s`
     Relative,
-}
-
-/// Format a duration as seconds with 3 decimal places.
-/// Negative durations include a leading `-`; positive ones have no sign prefix.
-fn format_seconds(diff: chrono::Duration) -> String {
-    let secs = diff.num_milliseconds() as f64 / 1000.0;
-    format!("{secs:.3}s")
 }
 
 /// Events emitted by the log table
@@ -824,11 +815,14 @@ impl LogTable {
                 }
                 TimestampMode::Delta => match prev_row_timestamp {
                     None => "0.000s".to_string(),
-                    Some(prev) => format_seconds(display_time.signed_duration_since(prev)),
+                    Some(prev) => format_time_diff(display_time.signed_duration_since(prev)),
                 },
                 TimestampMode::Relative => match time_zero_timestamp {
                     None => "0.000s".to_string(),
-                    Some(t0) => format_seconds(display_time.signed_duration_since(t0)),
+                    Some(t0) => {
+                        let secs = display_time.signed_duration_since(t0).as_seconds_f64();
+                        format!("{secs:.3}s")
+                    },
                 },
             };
 

--- a/src/ui/tabs/filter_tab/log_table.rs
+++ b/src/ui/tabs/filter_tab/log_table.rs
@@ -490,9 +490,7 @@ impl LogTable {
                 prev_row_timestamp,
             );
 
-            if let Some(ts) = store.adjusted_timestamp(&filtered_indices[row_index]) {
-                prev_row_timestamp = Some(ts);
-            }
+            prev_row_timestamp = store.adjusted_timestamp(&filtered_indices[row_index]);
 
             // Check if pointer is over this row for next frame
             if row.response().contains_pointer() {

--- a/src/ui/tabs/filter_tab/log_table.rs
+++ b/src/ui/tabs/filter_tab/log_table.rs
@@ -20,15 +20,18 @@ use std::sync::Arc;
 
 use crate::{
     core::{
-        LogStore, log_store::{LogLine, StoreID}
-    }, parser::format_time_diff, ui::{filter_highlight::FilterHighlight, tabs::filter_tab::filter_state::FilterState}
+        log_store::{LogLine, StoreID},
+        LogStore,
+    },
+    parser::format_time_diff,
+    ui::{filter_highlight::FilterHighlight, tabs::filter_tab::filter_state::FilterState},
 };
 use chrono::{DateTime, Local};
 use egui::{Color32, RichText, Ui};
 use egui_extras::{Column, TableBuilder};
 
 /// Controls how the timestamp column displays time values.
-#[derive(Default, Clone, Copy, PartialEq)]
+#[derive(Default, Clone, Copy, PartialEq, Eq)]
 pub enum TimestampMode {
     /// Show the absolute wall-clock time for each log line (default).
     /// Example: `2026-02-11 13:45:49.663`
@@ -783,16 +786,16 @@ impl LogTable {
             };
 
             let timestamp_str = match timestamp_mode {
-                TimestampMode::Absolute => {
-                    display_time.format("%Y-%m-%d %H:%M:%S%.3f").to_string()
-                }
-                TimestampMode::Delta => match prev_row_timestamp {
-                    None => "0.000s".to_string(),
-                    Some(prev) => format_time_diff(display_time.signed_duration_since(prev)),
-                },
+                TimestampMode::Absolute => display_time.format("%Y-%m-%d %H:%M:%S%.3f").to_string(),
+                TimestampMode::Delta => prev_row_timestamp.map_or_else(
+                    || "0.000s".to_string(),
+                    |prev| format_time_diff(display_time.signed_duration_since(prev)),
+                ),
                 TimestampMode::Relative(reference) => {
-                        let secs = display_time.signed_duration_since(reference).as_seconds_f64();
-                        format!("{secs:.3}s")
+                    let secs = display_time
+                        .signed_duration_since(reference)
+                        .as_seconds_f64();
+                    format!("{secs:.3}s")
                 }
             };
 

--- a/src/ui/tabs/filter_tab/log_table.rs
+++ b/src/ui/tabs/filter_tab/log_table.rs
@@ -40,7 +40,7 @@ pub enum TimestampMode {
     /// Show the elapsed time from a fixed time-zero reference.
     /// Defaults to the oldest visible message when no marker is pinned.
     /// Example: `120243.423s`
-    Relative,
+    Relative(DateTime<Local>),
 }
 
 /// Events emitted by the log table
@@ -317,7 +317,6 @@ impl LogTable {
                     dark_mode,
                     &mut filter.column_widths,
                     filter.timestamp_mode,
-                    filter.time_zero_store_id,
                 );
             });
 
@@ -381,26 +380,10 @@ impl LogTable {
         dark_mode: bool,
         column_widths: &mut ColumnWidths,
         timestamp_mode: TimestampMode,
-        time_zero_store_id: Option<StoreID>,
     ) {
-        // Resolve the time-zero reference timestamp for Relative mode.
-        // Priority: explicit user-pinned row > oldest visible message.
-        let time_zero_timestamp = if timestamp_mode == TimestampMode::Relative {
-            if let Some(id) = time_zero_store_id {
-                store.adjusted_timestamp(&id)
-            } else {
-                // Default: oldest visible message.
-                filtered_indices.first().and_then(|id| {
-                    store.adjusted_timestamp(id)
-                })
-            }
-        } else {
-            None
-        };
-
         table
             .header(20.0, |mut header| {
-                Self::render_header(&mut header, column_widths, timestamp_mode, time_zero_store_id);
+                Self::render_header(&mut header, column_widths, timestamp_mode);
             })
             .body(|body| {
                 profiling::scope!("LogTable::body");
@@ -416,7 +399,6 @@ impl LogTable {
                     events,
                     dark_mode,
                     timestamp_mode,
-                    time_zero_timestamp,
                 );
             });
     }
@@ -425,7 +407,6 @@ impl LogTable {
         header: &mut egui_extras::TableRow,
         column_widths: &mut ColumnWidths,
         timestamp_mode: TimestampMode,
-        time_zero_store_id: Option<StoreID>,
     ) {
         header.col(|ui| {
             column_widths.source = ui.available_width();
@@ -444,8 +425,7 @@ impl LogTable {
                     format!("Timestamp (UTC{offset})")
                 }
                 TimestampMode::Delta => "Δ Time".to_string(),
-                TimestampMode::Relative if time_zero_store_id.is_some() => "⏱ Relative (marker)".to_string(),
-                TimestampMode::Relative => "⏱ Relative".to_string(),
+                TimestampMode::Relative(_) => "⏱ Relative".to_string(),
             };
             ui.strong(label);
         });
@@ -472,7 +452,6 @@ impl LogTable {
         events: &mut Vec<LogTableEvent>,
         dark_mode: bool,
         timestamp_mode: TimestampMode,
-        time_zero_timestamp: Option<DateTime<Local>>,
     ) {
         let visible_lines = filtered_indices.len();
 
@@ -506,7 +485,6 @@ impl LogTable {
                 dark_mode,
                 timestamp_mode,
                 prev_row_timestamp,
-                time_zero_timestamp,
             );
 
             if let Some(ts) = store.adjusted_timestamp(&filtered_indices[row_index]) {
@@ -540,7 +518,6 @@ impl LogTable {
         dark_mode: bool,
         timestamp_mode: TimestampMode,
         prev_row_timestamp: Option<DateTime<Local>>,
-        time_zero_timestamp: Option<DateTime<Local>>,
     ) -> Option<LogTableEvent> {
         let row_index = row.index();
         let line_idx = filtered_indices[row_index];
@@ -580,7 +557,6 @@ impl LogTable {
             dark_mode,
             timestamp_mode,
             prev_row_timestamp,
-            time_zero_timestamp,
         );
 
         // Row-level interaction handling (union column and row responses)
@@ -620,7 +596,6 @@ impl LogTable {
         dark_mode: bool,
         timestamp_mode: TimestampMode,
         prev_row_timestamp: Option<DateTime<Local>>,
-        time_zero_timestamp: Option<DateTime<Local>>,
     ) -> egui::Response {
         let responses = [
             Self::render_source_column(
@@ -655,7 +630,6 @@ impl LogTable {
                 dark_mode,
                 timestamp_mode,
                 prev_row_timestamp,
-                time_zero_timestamp,
             ),
             Self::render_message_column(
                 row,
@@ -789,7 +763,6 @@ impl LogTable {
         dark_mode: bool,
         timestamp_mode: TimestampMode,
         prev_row_timestamp: Option<DateTime<Local>>,
-        time_zero_timestamp: Option<DateTime<Local>>,
     ) -> egui::Response {
         let mut response: Option<egui::Response> = None;
         let (_, col_response) = row.col(|ui| {
@@ -817,13 +790,10 @@ impl LogTable {
                     None => "0.000s".to_string(),
                     Some(prev) => format_time_diff(display_time.signed_duration_since(prev)),
                 },
-                TimestampMode::Relative => match time_zero_timestamp {
-                    None => "0.000s".to_string(),
-                    Some(t0) => {
-                        let secs = display_time.signed_duration_since(t0).as_seconds_f64();
+                TimestampMode::Relative(reference) => {
+                        let secs = display_time.signed_duration_since(reference).as_seconds_f64();
                         format!("{secs:.3}s")
-                    },
-                },
+                }
             };
 
             let text = RichText::new(timestamp_str).color(color);

--- a/src/ui/tabs/filter_tab/mod.rs
+++ b/src/ui/tabs/filter_tab/mod.rs
@@ -32,8 +32,8 @@ use crate::input::ShortcutAction;
 use crate::ui::filter_highlight::FilterHighlight;
 use crate::ui::session_state::{FilterToHighlightData, SessionState};
 use crate::ui::tabs::filter_tab::filter_state::FilterState;
-use crate::ui::tabs::LogCrabTab;
 use crate::ui::tabs::filter_tab::log_table::TimestampMode;
+use crate::ui::tabs::LogCrabTab;
 use crate::ui::windows::ChangeFilternameWindow;
 use egui::Ui;
 use std::collections::HashMap;
@@ -222,12 +222,12 @@ impl FilterView {
                     });
                 }
                 LogTableEvent::SetTimeZero { line_index } => {
-                    self.state.timestamp_mode = store.adjusted_timestamp(&line_index)
-                        .map( |timestamp| TimestampMode::Relative(timestamp))
-                        .unwrap_or_else(|| {
+                    self.state.timestamp_mode = store.adjusted_timestamp(&line_index).map_or_else(
+                        || {
                             log::warn!("Failed to set time zero for line index {line_index:?}");
                             TimestampMode::Absolute
-                        }
+                        },
+                        TimestampMode::Relative,
                     );
                 }
             }

--- a/src/ui/tabs/filter_tab/mod.rs
+++ b/src/ui/tabs/filter_tab/mod.rs
@@ -220,8 +220,12 @@ impl FilterView {
                         store_id: line_index,
                     });
                 }
-                // SetTimeZero and ClearTimeZero are consumed inside LogTable::render
-                LogTableEvent::SetTimeZero { .. } | LogTableEvent::ClearTimeZero => {}
+                LogTableEvent::SetTimeZero { line_index } => {
+                    self.state.time_zero_store_id = Some(line_index);
+                }
+                LogTableEvent::ClearTimeZero => {
+                    self.state.time_zero_store_id = None;
+                }
             }
         }
 

--- a/src/ui/tabs/filter_tab/mod.rs
+++ b/src/ui/tabs/filter_tab/mod.rs
@@ -220,6 +220,8 @@ impl FilterView {
                         store_id: line_index,
                     });
                 }
+                // SetTimeZero and ClearTimeZero are consumed inside LogTable::render
+                LogTableEvent::SetTimeZero { .. } | LogTableEvent::ClearTimeZero => {}
             }
         }
 

--- a/src/ui/tabs/filter_tab/mod.rs
+++ b/src/ui/tabs/filter_tab/mod.rs
@@ -223,9 +223,6 @@ impl FilterView {
                 LogTableEvent::SetTimeZero { line_index } => {
                     self.state.time_zero_store_id = Some(line_index);
                 }
-                LogTableEvent::ClearTimeZero => {
-                    self.state.time_zero_store_id = None;
-                }
             }
         }
 

--- a/src/ui/tabs/filter_tab/mod.rs
+++ b/src/ui/tabs/filter_tab/mod.rs
@@ -33,6 +33,7 @@ use crate::ui::filter_highlight::FilterHighlight;
 use crate::ui::session_state::{FilterToHighlightData, SessionState};
 use crate::ui::tabs::filter_tab::filter_state::FilterState;
 use crate::ui::tabs::LogCrabTab;
+use crate::ui::tabs::filter_tab::log_table::TimestampMode;
 use crate::ui::windows::ChangeFilternameWindow;
 use egui::Ui;
 use std::collections::HashMap;
@@ -221,7 +222,13 @@ impl FilterView {
                     });
                 }
                 LogTableEvent::SetTimeZero { line_index } => {
-                    self.state.time_zero_store_id = Some(line_index);
+                    self.state.timestamp_mode = store.adjusted_timestamp(&line_index)
+                        .map( |timestamp| TimestampMode::Relative(timestamp))
+                        .unwrap_or_else(|| {
+                            log::warn!("Failed to set time zero for line index {line_index:?}");
+                            TimestampMode::Absolute
+                        }
+                    );
                 }
             }
         }


### PR DESCRIPTION
Right-click the Timestamp column header to switch between three modes:

- Absolute: full wall-clock time (2026-02-11 13:45:49.663)
- Delta: elapsed time since the previous visible line (-0.532s)
- Relative: elapsed time from a fixed reference point (120243.423s)

Both Delta and Relative show seconds with 3 decimal places.

In Relative mode the default t0 is the oldest available message.
Any row can be pinned as time zero via the row right-click menu
('Set as time zero'); the marker can be cleared from the header menu.

Mode is per filter-tab and not persisted to disk.