### PR TITLE
fix: use 0-based line index for ClassifyLine sidecar call

### DIFF
--- a/src/ui/tabs/filter_tab/mod.rs
+++ b/src/ui/tabs/filter_tab/mod.rs
@@ -274,10 +274,9 @@ impl FilterView {
                 }
                 LogTableEvent::ClassifyLine { line_index, label } => {
                     let source_id = line_index.source_id();
-                    let classified_line_number = store
-                        .get_by_id(&line_index)
-                        .map(|l| l.line_number)
-                        .unwrap_or(0);
+                    // Use the 0-based line index that matches line_id.line_number
+                    // in the sidecar protocol, NOT the 1-based LogLine.line_number.
+                    let classified_line_number = line_index.line_index_within_source();
                     let Some(sidecar_config) = store.sidecar_config() else {
                         tracing::warn!("classify: no sidecar config set");
                         continue;


### PR DESCRIPTION
## Fix off-by-one in ClassifyLine sidecar call

### What breaks
When a user classifies a log line, the sidecar receives a wrong line identifier. The `classified_line_number` sent to `submit_sample()` is 1-based, but the `InputLine` objects in the accompanying `lines` array use 0-based indices. The sidecar cannot match the classified line to its input data — it either points to the wrong line (off-by-one) or to a nonexistent line when `filter_map` skips entries.

### Root cause (code evidence — Rung 3)

**ClassifyLine handler** (filter_tab/mod.rs:277-280) — **WRONG (1-based)**:
```rust
let classified_line_number = store
    .get_by_id(&line_index)
    .map(|l| l.line_number)     // ← 1-based (log_store.rs:745)
    .unwrap_or(0);
```

**ExplainAttention handler** (filter_tab/mod.rs:260-262) — **CORRECT (0-based)**:
```rust
// Use the 0-based line index that matches line_id.line_number
// in the scoring protocol, NOT the 1-based LogLine.line_number.
let target_ln = line_index.line_index_within_source();
```

**InputLine construction** (log_store.rs:1443-1449) — **0-based**:
```rust
(0..count).filter_map(|i| {
    ...
    Some(InputLine::new(0, i, ...))  // i is 0-based
})
```

`l.line_number` is documented as "1-based line number within the source file" (log_store.rs:745). The sidecar expects `classified_line_number` to match a `line_id.line_number` in the `lines` array, which are all 0-based.

### Intended behavior
`classified_line_number` must be 0-based, matching the `InputLine.line_id.line_number` values. The `ExplainAttention` handler (same file, 15 lines above) shows the correct pattern with an explicit comment.

### The fix
Replaced `store.get_by_id(&line_index).map(|l| l.line_number).unwrap_or(0)` with `line_index.line_index_within_source()`, matching `ExplainAttention`.

### Verification
```
cargo check: passes (dev profile)
```
Note: `cargo test` has a pre-existing compile error in `search_state.rs` (missing `hide_duplicates` field) unrelated to this change.

### Not changed
- No changes to `ExplainAttention`, sidecar client, proto definitions, or log_store
- No changes to the `get_sidecar_input_lines_for_source` indexing
