### PR TITLE
fix: remove sidecar_scores entry in remove_source()

### DIFF
--- a/src/core/log_store.rs
+++ b/src/core/log_store.rs
@@ -1035,6 +1035,7 @@ impl LogStore {
         drop(sources);
         // Also remove scores and explain session for this source
         self.scores.remove(&source_id);
+        self.sidecar_scores.remove(&source_id);
         self.explain_sessions
             .lock()
             .expect("explain_sessions lock poisoned")


### PR DESCRIPTION
## Fix sidecar_scores leak in remove_source()

### What breaks
When a source is removed (tab closed), its `sidecar_scores` entry — a `ScoreStore` containing four `ArcSwap<Vec<...>>` with O(line_count) memory — is never cleaned up. For large files with ML scoring enabled, this leaks hundreds of MBs of orphaned score data per removed source, persisting until app exit.

### Root cause (code evidence — Rung 3)

`LogStore` struct (log_store.rs:784-787):
```rust
scores: DashMap<u64, ScoreStore>,          // line 784
sidecar_scores: DashMap<u64, ScoreStore>,  // line 787 — parallel to scores
```

`remove_source()` (log_store.rs:1036-1041):
```rust
self.scores.remove(&source_id);           // ✓ cleaned up
// self.sidecar_scores — NOT cleaned up   // ← BUG
self.explain_sessions...remove(&source_id); // ✓ cleaned up
```

The `sidecar_scores` field is documented as "Parallel to `scores`" but was omitted from the cleanup block. Introduced in 39c037d when `sidecar_scores` was added to the struct.

### Intended behavior
All per-source state should be removed when a source is removed. The comment "Also remove scores and explain session for this source" and the cleanup of the two sibling fields make the intent clear.

### The fix
Added one line after `self.scores.remove(&source_id)`:
```rust
self.sidecar_scores.remove(&source_id);
```

### Verification
```
cargo check: passes (dev profile)
```
Note: `cargo test` has a pre-existing compile error in `search_state.rs` (missing `hide_duplicates` field) unrelated to this change.

### Not changed
- No changes to `ScoreStore`, `scores`, `explain_sessions`, or any other cleanup
- No changes to sidecar scoring logic


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removing a source now also removes its associated machine-learning scores, preventing stale scoring data from remaining behind.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->