### PR TITLE
fix: include hide_duplicates in histogram cache key

### DIFF
--- a/src/core/histogram_worker.rs
+++ b/src/core/histogram_worker.rs
@@ -74,6 +74,8 @@ pub struct HistogramCacheKey {
     pub zoom_range_ms: Option<(i64, i64)>,
     /// Whether to use ML sidecar score instead of heuristic score
     pub color_by_ml_score: bool,
+    /// Whether deduplication is active
+    pub hide_duplicates: bool,
 }
 
 /// Result from background histogram computation

--- a/src/core/search_state.rs
+++ b/src/core/search_state.rs
@@ -187,11 +187,12 @@ impl SearchState {
     }
 
     /// Get the search text that the current filtered indices were computed for.
-    pub fn indices_computed_for(&self) -> (&str, &str, bool, StoreVersion) {
+    pub fn indices_computed_for(&self) -> (&str, &str, bool, bool, StoreVersion) {
         (
             &self.indices_computed_for_text,
             &self.indices_computed_for_exclude,
             self.indices_computed_for_case,
+            self.indices_computed_for_dedup,
             self.indices_computed_for_version,
         )
     }

--- a/src/ui/tabs/filter_tab/histogram.rs
+++ b/src/ui/tabs/filter_tab/histogram.rs
@@ -209,7 +209,7 @@ impl Histogram {
 
         // Use the search parameters that the current filtered_indices were computed for,
         // not the current search_text (which may have changed while filter is pending)
-        let (indices_text, indices_exclude, indices_case, indices_version) =
+        let (indices_text, indices_exclude, indices_case, indices_dedup, indices_version) =
             filter_state.search.indices_computed_for();
         let search_str = indices_text.to_string();
         let exclude_str = indices_exclude.to_string();
@@ -227,6 +227,7 @@ impl Histogram {
             case_sensitive: indices_case,
             zoom_range_ms,
             color_by_ml_score,
+            hide_duplicates: indices_dedup,
         };
 
         // Poll for any completed results


### PR DESCRIPTION
## Include hide_duplicates in histogram cache key

### What breaks
Toggling "Hide Duplicate Lines" updates the table (deduped filtered indices) but the histogram shows stale pre-dedup data until another unrelated change (search text, zoom, etc.) forces a cache miss.

### Root cause (code evidence — Rung 3)

**HistogramCacheKey** (histogram_worker.rs:67-77) includes: `store_version`, `search_str`, `exclude_str`, `case_sensitive`, `zoom_range_ms`, `color_by_ml_score`. It does **not** include `hide_duplicates`.

**Cache key construction** (histogram.rs:217-230) calls `indices_computed_for()` which returns `(&str, &str, bool, StoreVersion)` — text, exclude, case, version. No dedup flag.

**Search state** (search_state.rs:64,92,175) tracks `indices_computed_for_dedup` internally and uses it to detect changes in `ensure_cache_valid()` (line 205), but `indices_computed_for()` (line 190) never exposes it to the histogram.

**Result**: when dedup toggles, `SearchState` recomputes `filtered_indices` (correct), but the histogram cache key is identical → cache HIT → stale histogram.

### Intended behavior
The histogram cache key must include every parameter that affects which lines are shown. `hide_duplicates` changes the filtered indices, so it must be in the key. Evidence: every other filter parameter (`search_str`, `exclude_str`, `case_sensitive`) is already included.

### The fix
1. Added `pub hide_duplicates: bool` to `HistogramCacheKey` (histogram_worker.rs)
2. Added `indices_computed_for_dedup` to the return tuple of `indices_computed_for()` (search_state.rs)
3. Set `hide_duplicates: indices_dedup` in the cache key construction (histogram.rs)

### Verification
```
cargo check: passes (dev profile)
```
Note: `cargo test` has a pre-existing compile error in `search_state.rs` (missing `hide_duplicates` field in test code) unrelated to this change.

### Not changed
- No changes to filter logic, dedup logic, or histogram computation
- No changes to `ensure_cache_valid()` or `FilterResult`
